### PR TITLE
Adding jam support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,12 @@
 		"name": "Rich Harris"
 	},
 	"main": "Ractive-events-tap.js",
+	"description": "Tap/fastclick event plugin for Ractive.js",
+	"jam": {
+		"dependencies": {
+			"Ractive": ">= 0.3.8"
+		}
+	},	
 	"devDependencies": {
 		"grunt": "~0.4.1",
 		"grunt-contrib-concat": "~0.3.0",


### PR DESCRIPTION
Jam requires a description (as will npm eventually), and based on: 

https://github.com/RactiveJS/Ractive/pull/431

Making the uppercase package a dependency.
