### PR TITLE
Add support for `npm install ractive-events-tap`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,12 @@ To get `ractive-events-tap.min.js` you can:
 - Use bower: `$ bower i ractive-events-tap`.
 - [Download the latest release](https://github.com/ractivejs/ractive-events-tap/releases/).
 - Clone the repo: `$ git clone https://github.com/ractivejs/ractive-events-tap.git`.
+- Use npm: `npm install ractive-events-tap`. 
 
-**plugin-specific instructions to go here...**
+## Notes:
+
+- If you use CommonJS make sure you also have Ractive itself installed.
+
 
 
 

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
 	},
 	"main": "ractive-events-tap.js",
 	"description": "Tap/fastclick event plugin for Ractive.js",
-	"dependencies": {
-		"ractive": "^0.5.8"
+	"peerDependencies": {
+		"ractive": "^0.6.0"
 	},
 	"devDependencies": {
 		"grunt": "~0.4.1",


### PR DESCRIPTION
I use CommonJS in my project and tried to include the tap event via npm.
Unfortunately it ships with it's own version of Ractive and therefore it extends this version.
This can be fixed by moving the dependency to `devDependencies` so in your project the plugin uses the Ractive version from your main `node_modules` folder.