### PR TITLE
Stop on-tap from firing twice on Windows

### DIFF
--- a/src/ractive-events-tap.js
+++ b/src/ractive-events-tap.js
@@ -16,19 +16,17 @@ function TapHandler ( node, callback ) {
 
 TapHandler.prototype = {
 	bind ( node ) {
-		if ('ontouchstart' in window) {
-			// ...and touch events
-			node.addEventListener("touchstart", handleTouchstart, false);
+		// listen for mouse/pointer events...
+		if (window.navigator.pointerEnabled) {
+			node.addEventListener("pointerdown", handleMousedown, false);
+		} else if (window.navigator.msPointerEnabled) {
+			node.addEventListener("MSPointerDown", handleMousedown, false);
 		} else {
-			// listen for mouse/pointer events...
-			if (window.navigator.pointerEnabled) {
-				node.addEventListener("pointerdown", handleMousedown, false);
-			} else if (window.navigator.msPointerEnabled) {
-				node.addEventListener("MSPointerDown", handleMousedown, false);
-			} else {
-				node.addEventListener("mousedown", handleMousedown, false);
-			}
+			node.addEventListener("mousedown", handleMousedown, false);
 		}
+
+		// ...and touch events
+		if (!window.navigator.pointerEnabled && !window.navigator.msPointerEnabled) node.addEventListener("touchstart", handleTouchstart, false);
 		
 		// native buttons, and <input type='button'> elements, should fire a tap event
 		// when the space key is pressed

--- a/src/ractive-events-tap.js
+++ b/src/ractive-events-tap.js
@@ -18,15 +18,15 @@ TapHandler.prototype = {
 	bind ( node ) {
 		// listen for mouse/pointer events...
 		if (window.navigator.pointerEnabled) {
-			node.addEventListener("pointerdown", handleMousedown, false);
+			node.addEventListener( 'pointerdown', handleMousedown, false );
 		} else if (window.navigator.msPointerEnabled) {
-			node.addEventListener("MSPointerDown", handleMousedown, false);
+			node.addEventListener( 'MSPointerDown', handleMousedown, false );
 		} else {
-			node.addEventListener("mousedown", handleMousedown, false);
+			node.addEventListener( 'mousedown', handleMousedown, false );
+			
+			// ...and touch events
+			node.addEventListener( 'touchstart', handleTouchstart, false );
 		}
-
-		// ...and touch events
-		if (!window.navigator.pointerEnabled && !window.navigator.msPointerEnabled) node.addEventListener("touchstart", handleTouchstart, false);
 		
 		// native buttons, and <input type='button'> elements, should fire a tap event
 		// when the space key is pressed

--- a/src/ractive-events-tap.js
+++ b/src/ractive-events-tap.js
@@ -16,18 +16,20 @@ function TapHandler ( node, callback ) {
 
 TapHandler.prototype = {
 	bind ( node ) {
-		// listen for mouse/pointer events...
-		if ( window.navigator.pointerEnabled ) {
-			node.addEventListener( 'pointerdown', handleMousedown, false );
-		} else if ( window.navigator.msPointerEnabled ) {
-			node.addEventListener( 'MSPointerDown', handleMousedown, false );
+		if ('ontouchstart' in window) {
+			// ...and touch events
+			node.addEventListener("touchstart", handleTouchstart, false);
 		} else {
-			node.addEventListener( 'mousedown', handleMousedown, false );
+			// listen for mouse/pointer events...
+			if (window.navigator.pointerEnabled) {
+				node.addEventListener("pointerdown", handleMousedown, false);
+			} else if (window.navigator.msPointerEnabled) {
+				node.addEventListener("MSPointerDown", handleMousedown, false);
+			} else {
+				node.addEventListener("mousedown", handleMousedown, false);
+			}
 		}
-
-		// ...and touch events
-		node.addEventListener( 'touchstart', handleTouchstart, false );
-
+		
 		// native buttons, and <input type='button'> elements, should fire a tap event
 		// when the space key is pressed
 		if ( node.tagName === 'BUTTON' || node.type === 'button' ) {


### PR DESCRIPTION
Register either the touchstart event or the pointerdown event. Response to issue #8 