### PR TITLE
Windows IE Edge Preview Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,12 @@ var ractive = new Ractive({
 
 If you include ractive-events-tap as a script tag, it will 'self-register' with the global `Ractive` object, and all Ractive instances will be able to use it.
 
+## Commands when Contributing
 
+```bash
+npm run build #compile
+npm run test # run chrome 55+
+```
 
 ## License
 

--- a/dist/ractive-events-tap.es.js
+++ b/dist/ractive-events-tap.es.js
@@ -17,7 +17,7 @@ function TapHandler ( node, callback ) {
 TapHandler.prototype = {
 	bind: function bind ( node ) {
 		// listen for mouse/pointer events...
-		if ( window.pointerEvent || window.navigator.pointerEnabled ) {
+		if ( window.PointerEvent || window.navigator.pointerEnabled ) {
 			node.addEventListener( 'pointerdown', handleMousedown, false );
 		} else if ( window.MSPointerEvent || window.navigator.msPointerEnabled ) {
 			node.addEventListener( 'MSPointerDown', handleMousedown, false );
@@ -93,11 +93,11 @@ TapHandler.prototype = {
 			document.removeEventListener( 'mousemove', handleMousemove, false );
 		};
 
-		if ( window.pointerEvent || window.navigator.pointerEnabled ) {
+		if ( window.PointerEvent || window.navigator.pointerEnabled ) {
 			this.node.addEventListener( 'pointerup', handleMouseup, false );
 			document.addEventListener( 'pointermove', handleMousemove, false );
 			document.addEventListener( 'pointercancel', cancel, false );
-		} else if ( window.pointerEvent || window.navigator.msPointerEnabled ) {
+		} else if ( window.PointerEvent || window.navigator.msPointerEnabled ) {
 			this.node.addEventListener( 'MSPointerUp', handleMouseup, false );
 			document.addEventListener( 'MSPointerMove', handleMousemove, false );
 			document.addEventListener( 'MSPointerCancel', cancel, false );

--- a/dist/ractive-events-tap.es.js
+++ b/dist/ractive-events-tap.es.js
@@ -17,9 +17,9 @@ function TapHandler ( node, callback ) {
 TapHandler.prototype = {
 	bind: function bind ( node ) {
 		// listen for mouse/pointer events...
-		if (window.navigator.pointerEnabled) {
+		if ( window.pointerEvent || window.navigator.pointerEnabled ) {
 			node.addEventListener( 'pointerdown', handleMousedown, false );
-		} else if (window.navigator.msPointerEnabled) {
+		} else if ( window.MSPointerEvent || window.navigator.msPointerEnabled ) {
 			node.addEventListener( 'MSPointerDown', handleMousedown, false );
 		} else {
 			node.addEventListener( 'mousedown', handleMousedown, false );
@@ -93,11 +93,11 @@ TapHandler.prototype = {
 			document.removeEventListener( 'mousemove', handleMousemove, false );
 		};
 
-		if ( window.navigator.pointerEnabled ) {
+		if ( window.pointerEvent || window.navigator.pointerEnabled ) {
 			this.node.addEventListener( 'pointerup', handleMouseup, false );
 			document.addEventListener( 'pointermove', handleMousemove, false );
 			document.addEventListener( 'pointercancel', cancel, false );
-		} else if ( window.navigator.msPointerEnabled ) {
+		} else if ( window.pointerEvent || window.navigator.msPointerEnabled ) {
 			this.node.addEventListener( 'MSPointerUp', handleMouseup, false );
 			document.addEventListener( 'MSPointerMove', handleMousemove, false );
 			document.addEventListener( 'MSPointerCancel', cancel, false );

--- a/dist/ractive-events-tap.umd.js
+++ b/dist/ractive-events-tap.umd.js
@@ -23,7 +23,7 @@ function TapHandler ( node, callback ) {
 TapHandler.prototype = {
 	bind: function bind ( node ) {
 		// listen for mouse/pointer events...
-		if ( window.pointerEvent || window.navigator.pointerEnabled ) {
+		if ( window.PointerEvent || window.navigator.pointerEnabled ) {
 			node.addEventListener( 'pointerdown', handleMousedown, false );
 		} else if ( window.MSPointerEvent || window.navigator.msPointerEnabled ) {
 			node.addEventListener( 'MSPointerDown', handleMousedown, false );
@@ -99,11 +99,11 @@ TapHandler.prototype = {
 			document.removeEventListener( 'mousemove', handleMousemove, false );
 		};
 
-		if ( window.pointerEvent || window.navigator.pointerEnabled ) {
+		if ( window.PointerEvent || window.navigator.pointerEnabled ) {
 			this.node.addEventListener( 'pointerup', handleMouseup, false );
 			document.addEventListener( 'pointermove', handleMousemove, false );
 			document.addEventListener( 'pointercancel', cancel, false );
-		} else if ( window.pointerEvent || window.navigator.msPointerEnabled ) {
+		} else if ( window.PointerEvent || window.navigator.msPointerEnabled ) {
 			this.node.addEventListener( 'MSPointerUp', handleMouseup, false );
 			document.addEventListener( 'MSPointerMove', handleMousemove, false );
 			document.addEventListener( 'MSPointerCancel', cancel, false );

--- a/dist/ractive-events-tap.umd.js
+++ b/dist/ractive-events-tap.umd.js
@@ -2,210 +2,210 @@
 	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
 	(global.Ractive = global.Ractive || {}, global.Ractive.events = global.Ractive.events || {}, global.Ractive.events.tap = factory());
-}(this, function () { 'use strict';
+}(this, (function () { 'use strict';
 
-	var DISTANCE_THRESHOLD = 5; // maximum pixels pointer can move before cancel
-	var TIME_THRESHOLD = 400;   // maximum milliseconds between down and up before cancel
+var DISTANCE_THRESHOLD = 5; // maximum pixels pointer can move before cancel
+var TIME_THRESHOLD = 400;   // maximum milliseconds between down and up before cancel
 
-	function tap ( node, callback ) {
-		return new TapHandler( node, callback );
-	}
+function tap ( node, callback ) {
+	return new TapHandler( node, callback );
+}
 
-	function TapHandler ( node, callback ) {
-		this.node = node;
-		this.callback = callback;
+function TapHandler ( node, callback ) {
+	this.node = node;
+	this.callback = callback;
 
-		this.preventMousedownEvents = false;
+	this.preventMousedownEvents = false;
 
-		this.bind( node );
-	}
+	this.bind( node );
+}
 
-	TapHandler.prototype = {
-		bind: function bind ( node ) {
-			// listen for mouse/pointer events...
-			if (window.navigator.pointerEnabled) {
-				node.addEventListener( 'pointerdown', handleMousedown, false );
-			} else if (window.navigator.msPointerEnabled) {
-				node.addEventListener( 'MSPointerDown', handleMousedown, false );
-			} else {
-				node.addEventListener( 'mousedown', handleMousedown, false );
+TapHandler.prototype = {
+	bind: function bind ( node ) {
+		// listen for mouse/pointer events...
+		if ( window.pointerEvent || window.navigator.pointerEnabled ) {
+			node.addEventListener( 'pointerdown', handleMousedown, false );
+		} else if ( window.MSPointerEvent || window.navigator.msPointerEnabled ) {
+			node.addEventListener( 'MSPointerDown', handleMousedown, false );
+		} else {
+			node.addEventListener( 'mousedown', handleMousedown, false );
 
-				// ...and touch events
-				node.addEventListener( 'touchstart', handleTouchstart, false );
-			}
+			// ...and touch events
+			node.addEventListener( 'touchstart', handleTouchstart, false );
+		}
 
-			// native buttons, and <input type='button'> elements, should fire a tap event
-			// when the space key is pressed
-			if ( node.tagName === 'BUTTON' || node.type === 'button' ) {
-				node.addEventListener( 'focus', handleFocus, false );
-			}
+		// native buttons, and <input type='button'> elements, should fire a tap event
+		// when the space key is pressed
+		if ( node.tagName === 'BUTTON' || node.type === 'button' ) {
+			node.addEventListener( 'focus', handleFocus, false );
+		}
 
-			node.__tap_handler__ = this;
-		},
+		node.__tap_handler__ = this;
+	},
 
-		fire: function fire ( event, x, y ) {
-			this.callback({
-				node: this.node,
-				original: event,
-				x: x,
-				y: y
-			});
-		},
+	fire: function fire ( event, x, y ) {
+		this.callback({
+			node: this.node,
+			original: event,
+			x: x,
+			y: y
+		});
+	},
 
-		mousedown: function mousedown ( event ) {
-			var this$1 = this;
+	mousedown: function mousedown ( event ) {
+		var this$1 = this;
 
-			if ( this.preventMousedownEvents ) {
+		if ( this.preventMousedownEvents ) {
+			return;
+		}
+
+		if ( event.which !== undefined && event.which !== 1 ) {
+			return;
+		}
+
+		var x = event.clientX;
+		var y = event.clientY;
+
+		// This will be null for mouse events.
+		var pointerId = event.pointerId;
+
+		var handleMouseup = function (event) {
+			if ( event.pointerId != pointerId ) {
 				return;
 			}
 
-			if ( event.which !== undefined && event.which !== 1 ) {
+			this$1.fire( event, x, y );
+			cancel();
+		};
+
+		var handleMousemove = function (event) {
+			if ( event.pointerId != pointerId ) {
 				return;
 			}
 
-			var x = event.clientX;
-			var y = event.clientY;
-
-			// This will be null for mouse events.
-			var pointerId = event.pointerId;
-
-			var handleMouseup = function (event) {
-				if ( event.pointerId != pointerId ) {
-					return;
-				}
-
-				this$1.fire( event, x, y );
+			if ( ( Math.abs( event.clientX - x ) >= DISTANCE_THRESHOLD ) || ( Math.abs( event.clientY - y ) >= DISTANCE_THRESHOLD ) ) {
 				cancel();
-			};
+			}
+		};
 
-			var handleMousemove = function (event) {
-				if ( event.pointerId != pointerId ) {
-					return;
-				}
+		var cancel = function () {
+			this$1.node.removeEventListener( 'MSPointerUp', handleMouseup, false );
+			document.removeEventListener( 'MSPointerMove', handleMousemove, false );
+			document.removeEventListener( 'MSPointerCancel', cancel, false );
+			this$1.node.removeEventListener( 'pointerup', handleMouseup, false );
+			document.removeEventListener( 'pointermove', handleMousemove, false );
+			document.removeEventListener( 'pointercancel', cancel, false );
+			this$1.node.removeEventListener( 'click', handleMouseup, false );
+			document.removeEventListener( 'mousemove', handleMousemove, false );
+		};
 
-				if ( ( Math.abs( event.clientX - x ) >= DISTANCE_THRESHOLD ) || ( Math.abs( event.clientY - y ) >= DISTANCE_THRESHOLD ) ) {
-					cancel();
-				}
-			};
+		if ( window.pointerEvent || window.navigator.pointerEnabled ) {
+			this.node.addEventListener( 'pointerup', handleMouseup, false );
+			document.addEventListener( 'pointermove', handleMousemove, false );
+			document.addEventListener( 'pointercancel', cancel, false );
+		} else if ( window.pointerEvent || window.navigator.msPointerEnabled ) {
+			this.node.addEventListener( 'MSPointerUp', handleMouseup, false );
+			document.addEventListener( 'MSPointerMove', handleMousemove, false );
+			document.addEventListener( 'MSPointerCancel', cancel, false );
+		} else {
+			this.node.addEventListener( 'click', handleMouseup, false );
+			document.addEventListener( 'mousemove', handleMousemove, false );
+		}
 
-			var cancel = function () {
-				this$1.node.removeEventListener( 'MSPointerUp', handleMouseup, false );
-				document.removeEventListener( 'MSPointerMove', handleMousemove, false );
-				document.removeEventListener( 'MSPointerCancel', cancel, false );
-				this$1.node.removeEventListener( 'pointerup', handleMouseup, false );
-				document.removeEventListener( 'pointermove', handleMousemove, false );
-				document.removeEventListener( 'pointercancel', cancel, false );
-				this$1.node.removeEventListener( 'click', handleMouseup, false );
-				document.removeEventListener( 'mousemove', handleMousemove, false );
-			};
+		setTimeout( cancel, TIME_THRESHOLD );
+	},
 
-			if ( window.navigator.pointerEnabled ) {
-				this.node.addEventListener( 'pointerup', handleMouseup, false );
-				document.addEventListener( 'pointermove', handleMousemove, false );
-				document.addEventListener( 'pointercancel', cancel, false );
-			} else if ( window.navigator.msPointerEnabled ) {
-				this.node.addEventListener( 'MSPointerUp', handleMouseup, false );
-				document.addEventListener( 'MSPointerMove', handleMousemove, false );
-				document.addEventListener( 'MSPointerCancel', cancel, false );
-			} else {
-				this.node.addEventListener( 'click', handleMouseup, false );
-				document.addEventListener( 'mousemove', handleMousemove, false );
+	touchdown: function touchdown ( event ) {
+		var this$1 = this;
+
+		var touch = event.touches[0];
+
+		var x = touch.clientX;
+		var y = touch.clientY;
+
+		var finger = touch.identifier;
+
+		var handleTouchup = function (event) {
+			var touch = event.changedTouches[0];
+
+			if ( touch.identifier !== finger ) {
+				cancel();
+				return;
 			}
 
-			setTimeout( cancel, TIME_THRESHOLD );
-		},
+			event.preventDefault(); // prevent compatibility mouse event
 
-		touchdown: function touchdown ( event ) {
-			var this$1 = this;
+			// for the benefit of mobile Firefox and old Android browsers, we need this absurd hack.
+			this$1.preventMousedownEvents = true;
+			clearTimeout( this$1.preventMousedownTimeout );
+
+			this$1.preventMousedownTimeout = setTimeout( function () {
+				this$1.preventMousedownEvents = false;
+			}, 400 );
+
+			this$1.fire( event, x, y );
+			cancel();
+		};
+
+		var handleTouchmove = function (event) {
+			if ( event.touches.length !== 1 || event.touches[0].identifier !== finger ) {
+				cancel();
+			}
 
 			var touch = event.touches[0];
-
-			var x = touch.clientX;
-			var y = touch.clientY;
-
-			var finger = touch.identifier;
-
-			var handleTouchup = function (event) {
-				var touch = event.changedTouches[0];
-
-				if ( touch.identifier !== finger ) {
-					cancel();
-					return;
-				}
-
-				event.preventDefault(); // prevent compatibility mouse event
-
-				// for the benefit of mobile Firefox and old Android browsers, we need this absurd hack.
-				this$1.preventMousedownEvents = true;
-				clearTimeout( this$1.preventMousedownTimeout );
-
-				this$1.preventMousedownTimeout = setTimeout( function () {
-					this$1.preventMousedownEvents = false;
-				}, 400 );
-
-				this$1.fire( event, x, y );
+			if ( ( Math.abs( touch.clientX - x ) >= DISTANCE_THRESHOLD ) || ( Math.abs( touch.clientY - y ) >= DISTANCE_THRESHOLD ) ) {
 				cancel();
-			};
+			}
+		};
 
-			var handleTouchmove = function (event) {
-				if ( event.touches.length !== 1 || event.touches[0].identifier !== finger ) {
-					cancel();
-				}
+		var cancel = function () {
+			this$1.node.removeEventListener( 'touchend', handleTouchup, false );
+			window.removeEventListener( 'touchmove', handleTouchmove, false );
+			window.removeEventListener( 'touchcancel', cancel, false );
+		};
 
-				var touch = event.touches[0];
-				if ( ( Math.abs( touch.clientX - x ) >= DISTANCE_THRESHOLD ) || ( Math.abs( touch.clientY - y ) >= DISTANCE_THRESHOLD ) ) {
-					cancel();
-				}
-			};
+		this.node.addEventListener( 'touchend', handleTouchup, false );
+		window.addEventListener( 'touchmove', handleTouchmove, false );
+		window.addEventListener( 'touchcancel', cancel, false );
 
-			var cancel = function () {
-				this$1.node.removeEventListener( 'touchend', handleTouchup, false );
-				window.removeEventListener( 'touchmove', handleTouchmove, false );
-				window.removeEventListener( 'touchcancel', cancel, false );
-			};
+		setTimeout( cancel, TIME_THRESHOLD );
+	},
 
-			this.node.addEventListener( 'touchend', handleTouchup, false );
-			window.addEventListener( 'touchmove', handleTouchmove, false );
-			window.addEventListener( 'touchcancel', cancel, false );
+	teardown: function teardown () {
+		var node = this.node;
 
-			setTimeout( cancel, TIME_THRESHOLD );
-		},
-
-		teardown: function teardown () {
-			var node = this.node;
-
-			node.removeEventListener( 'pointerdown',   handleMousedown, false );
-			node.removeEventListener( 'MSPointerDown', handleMousedown, false );
-			node.removeEventListener( 'mousedown',     handleMousedown, false );
-			node.removeEventListener( 'touchstart',    handleTouchstart, false );
-			node.removeEventListener( 'focus',         handleFocus, false );
-		}
-	};
-
-	function handleMousedown ( event ) {
-		this.__tap_handler__.mousedown( event );
+		node.removeEventListener( 'pointerdown',   handleMousedown, false );
+		node.removeEventListener( 'MSPointerDown', handleMousedown, false );
+		node.removeEventListener( 'mousedown',     handleMousedown, false );
+		node.removeEventListener( 'touchstart',    handleTouchstart, false );
+		node.removeEventListener( 'focus',         handleFocus, false );
 	}
+};
 
-	function handleTouchstart ( event ) {
-		this.__tap_handler__.touchdown( event );
+function handleMousedown ( event ) {
+	this.__tap_handler__.mousedown( event );
+}
+
+function handleTouchstart ( event ) {
+	this.__tap_handler__.touchdown( event );
+}
+
+function handleFocus () {
+	this.addEventListener( 'keydown', handleKeydown, false );
+	this.addEventListener( 'blur', handleBlur, false );
+}
+
+function handleBlur () {
+	this.removeEventListener( 'keydown', handleKeydown, false );
+	this.removeEventListener( 'blur', handleBlur, false );
+}
+
+function handleKeydown ( event ) {
+	if ( event.which === 32 ) { // space key
+		this.__tap_handler__.fire();
 	}
+}
 
-	function handleFocus () {
-		this.addEventListener( 'keydown', handleKeydown, false );
-		this.addEventListener( 'blur', handleBlur, false );
-	}
+return tap;
 
-	function handleBlur () {
-		this.removeEventListener( 'keydown', handleKeydown, false );
-		this.removeEventListener( 'blur', handleBlur, false );
-	}
-
-	function handleKeydown ( event ) {
-		if ( event.which === 32 ) { // space key
-			this.__tap_handler__.fire();
-		}
-	}
-
-	return tap;
-
-}));
+})));

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
     "build": "rm -rf dist && rollup -c",
     "prepublish": "npm run build",
     "lint": "eslint src",
-    "test": "open test/index.html"
+    "test": "chrome ./test/index.html"
   }
 }

--- a/src/ractive-events-tap.js
+++ b/src/ractive-events-tap.js
@@ -17,7 +17,7 @@ function TapHandler ( node, callback ) {
 TapHandler.prototype = {
 	bind ( node ) {
 		// listen for mouse/pointer events...
-		if ( window.pointerEvent || window.navigator.pointerEnabled ) {
+		if ( window.PointerEvent || window.navigator.pointerEnabled ) {
 			node.addEventListener( 'pointerdown', handleMousedown, false );
 		} else if ( window.MSPointerEvent || window.navigator.msPointerEnabled ) {
 			node.addEventListener( 'MSPointerDown', handleMousedown, false );
@@ -91,11 +91,11 @@ TapHandler.prototype = {
 			document.removeEventListener( 'mousemove', handleMousemove, false );
 		};
 
-		if ( window.pointerEvent || window.navigator.pointerEnabled ) {
+		if ( window.PointerEvent || window.navigator.pointerEnabled ) {
 			this.node.addEventListener( 'pointerup', handleMouseup, false );
 			document.addEventListener( 'pointermove', handleMousemove, false );
 			document.addEventListener( 'pointercancel', cancel, false );
-		} else if ( window.pointerEvent || window.navigator.msPointerEnabled ) {
+		} else if ( window.PointerEvent || window.navigator.msPointerEnabled ) {
 			this.node.addEventListener( 'MSPointerUp', handleMouseup, false );
 			document.addEventListener( 'MSPointerMove', handleMousemove, false );
 			document.addEventListener( 'MSPointerCancel', cancel, false );

--- a/src/ractive-events-tap.js
+++ b/src/ractive-events-tap.js
@@ -17,9 +17,9 @@ function TapHandler ( node, callback ) {
 TapHandler.prototype = {
 	bind ( node ) {
 		// listen for mouse/pointer events...
-		if (window.navigator.pointerEnabled) {
+		if ( window.pointerEvent || window.navigator.pointerEnabled ) {
 			node.addEventListener( 'pointerdown', handleMousedown, false );
-		} else if (window.navigator.msPointerEnabled) {
+		} else if ( window.MSPointerEvent || window.navigator.msPointerEnabled ) {
 			node.addEventListener( 'MSPointerDown', handleMousedown, false );
 		} else {
 			node.addEventListener( 'mousedown', handleMousedown, false );
@@ -91,11 +91,11 @@ TapHandler.prototype = {
 			document.removeEventListener( 'mousemove', handleMousemove, false );
 		};
 
-		if ( window.navigator.pointerEnabled ) {
+		if ( window.pointerEvent || window.navigator.pointerEnabled ) {
 			this.node.addEventListener( 'pointerup', handleMouseup, false );
 			document.addEventListener( 'pointermove', handleMousemove, false );
 			document.addEventListener( 'pointercancel', cancel, false );
-		} else if ( window.navigator.msPointerEnabled ) {
+		} else if ( window.pointerEvent || window.navigator.msPointerEnabled ) {
 			this.node.addEventListener( 'MSPointerUp', handleMouseup, false );
 			document.addEventListener( 'MSPointerMove', handleMousemove, false );
 			document.addEventListener( 'MSPointerCancel', cancel, false );

--- a/test/index.html
+++ b/test/index.html
@@ -8,7 +8,7 @@
 <body>
 	<div id='mocha'></div>
 
-	<script src='../node_modules/simulant/dist/simulant.js'></script>
+	<script src='../node_modules/simulant/dist/simulant.umd.js'></script>
 	<script src='../node_modules/ractive/ractive-legacy.js'></script>
 	<script src='../dist/ractive-events-tap.umd.js'></script>
 	<script src='../node_modules/mocha/mocha.js'></script>

--- a/test/tests.js
+++ b/test/tests.js
@@ -60,13 +60,13 @@ describe( 'ractive-events-tap', function () {
 
 	it( 'IE Edge window.pointerEnabled == undefined should still result in a tap event', function ( done ) {
 		var ractive, node, tapped;
-		
+
 		window.navigator.pointerEnabled = undefined;
-		window.pointerEvent = new PointerEvent("pointerdown", 
+		window.PointerEvent = new PointerEvent("pointerdown", 
 			{
 				pointerId: 1,
-				bubbles: true, 
-				cancelable: true, 
+				bubbles: true,
+				cancelable: true,
 				pointerType: "touch",
 				width: 100,
 				height: 100,

--- a/test/tests.js
+++ b/test/tests.js
@@ -62,16 +62,9 @@ describe( 'ractive-events-tap', function () {
 		var ractive, node, tapped;
 
 		window.navigator.pointerEnabled = undefined;
-		window.PointerEvent = new PointerEvent("pointerdown", 
-			{
-				pointerId: 1,
-				bubbles: true,
-				cancelable: true,
-				pointerType: "touch",
-				width: 100,
-				height: 100,
-				isPrimary: true
-			});
+		/** NOTE removed mocking PointerEvent, it should be handled in the Browser itself. Ex. Chrome 56+
+		 * Because window.PointerEvent = new PointerEvent() is just very incorrect.
+		 * window.PointerEvent = new PointerEvent("pointerdown", {}); */
 
 		ractive = new Ractive({
 			el: fixture,

--- a/test/tests.js
+++ b/test/tests.js
@@ -57,4 +57,43 @@ describe( 'ractive-events-tap', function () {
 			done();
 		}, 100 );
 	});
+
+	it( 'IE Edge window.pointerEnabled == undefined should still result in a tap event', function ( done ) {
+		var ractive, node, tapped;
+		
+		window.navigator.pointerEnabled = undefined;
+		window.pointerEvent = new PointerEvent("pointerdown", 
+			{
+				pointerId: 1,
+				bubbles: true, 
+				cancelable: true, 
+				pointerType: "touch",
+				width: 100,
+				height: 100,
+				isPrimary: true
+			});
+
+		ractive = new Ractive({
+			el: fixture,
+			template: '<button id="test" on-tap="tap">tap me</button>',
+			debug: true
+		});
+
+		node = ractive.nodes.test;
+
+		ractive.on( 'tap', function () {
+			tapped = true;
+		});
+
+		assert.equal( tapped, undefined );
+		simulant.fire( node, 'mousedown' );
+		simulant.fire( node, 'pointerdown' );
+		simulant.fire( node, 'pointerup' );
+		assert.equal( tapped, true );
+
+		setTimeout( function () {
+			assert.equal( tapped, true );
+			done();
+		}, 100 );
+	});
 });


### PR DESCRIPTION
MS released a new IE Edge Preview that leverages the new [window.PointerEvent](https://msdn.microsoft.com/library/hh772103(v=vs.85).aspx) API. This removes the `window.navigator.pointerEnabled` in the fall/October release version. And will break anyone who uses this plugin.

Added some unit tests to `try and simulate IE Edge` - but used Chrome 55+ since it has an initial implementation of window.PointerEvent.

While the initial test now fails in Chrome it fixes issues on IE Edge. Note : Firefox works fine for the first 2 tests.