### PR TITLE
Jaws ie click

### DIFF
--- a/dist/ractive-events-tap.es.js
+++ b/dist/ractive-events-tap.es.js
@@ -10,6 +10,7 @@ function TapHandler ( node, callback ) {
 	this.callback = callback;
 
 	this.preventMousedownEvents = false;
+	this.preventClickEvents = false;
 
 	this.bind( node );
 }
@@ -57,6 +58,7 @@ TapHandler.prototype = {
 			return;
 		}
 
+		this.preventClickEvents = true;
 		var x = event.clientX;
 		var y = event.clientY;
 
@@ -106,6 +108,7 @@ TapHandler.prototype = {
 			document.addEventListener( 'mousemove', handleMousemove, false );
 		}
 
+		this.node.removeEventListener( 'click', handleFocusClick, false );
 		setTimeout( cancel, TIME_THRESHOLD );
 	},
 
@@ -185,7 +188,9 @@ function handleTouchstart ( event ) {
 }
 
 function handleFocusClick ( event ) {
-	this.__tap_handler__.fire( event );
+	if (! this.__tap_handler__.preventClickEvents) {
+		this.__tap_handler__.fire( event );
+	}
 }
 
 function handleFocus () {
@@ -198,6 +203,7 @@ function handleBlur () {
 	this.removeEventListener( 'keydown', handleKeydown, false );
 	this.removeEventListener( 'blur', handleBlur, false );
 	this.removeEventListener( 'click', handleFocusClick, false );
+	this.__tap_handler__.preventClickEvents = false;
 }
 
 function handleKeydown ( event ) {

--- a/dist/ractive-events-tap.es.js
+++ b/dist/ractive-events-tap.es.js
@@ -101,9 +101,10 @@ TapHandler.prototype = {
 			this.node.addEventListener( 'MSPointerUp', handleMouseup, false );
 			document.addEventListener( 'MSPointerMove', handleMousemove, false );
 			document.addEventListener( 'MSPointerCancel', cancel, false );
+		} else {
+			this.node.addEventListener( 'click', handleMouseup, false );
+			document.addEventListener( 'mousemove', handleMousemove, false );
 		}
-		this.node.addEventListener( 'click', handleMouseup, false );
-		document.addEventListener( 'mousemove', handleMousemove, false );
 
 		setTimeout( cancel, TIME_THRESHOLD );
 	},
@@ -183,18 +184,25 @@ function handleTouchstart ( event ) {
 	this.__tap_handler__.touchdown( event );
 }
 
+function handleFocusClick ( event ) {
+	this.__tap_handler__.fire( event );
+}
+
 function handleFocus () {
 	this.addEventListener( 'keydown', handleKeydown, false );
 	this.addEventListener( 'blur', handleBlur, false );
+	this.addEventListener( 'click', handleFocusClick, false );
 }
 
 function handleBlur () {
 	this.removeEventListener( 'keydown', handleKeydown, false );
 	this.removeEventListener( 'blur', handleBlur, false );
+	this.removeEventListener( 'click', handleFocusClick, false );
 }
 
 function handleKeydown ( event ) {
 	if ( event.which === 32 || event.which === 13 ) { // space key
+		this.removeEventListener( 'click', handleFocusClick, false );
 		this.__tap_handler__.fire();
 	}
 }

--- a/dist/ractive-events-tap.es.js
+++ b/dist/ractive-events-tap.es.js
@@ -94,14 +94,19 @@ TapHandler.prototype = {
 		};
 
 		if ( window.navigator.pointerEnabled ) {
+            console.log('ractive-events-tap pointerEnabled');
 			this.node.addEventListener( 'pointerup', handleMouseup, false );
 			document.addEventListener( 'pointermove', handleMousemove, false );
 			document.addEventListener( 'pointercancel', cancel, false );
+			this.node.addEventListener( 'click', handleMouseup, false );
 		} else if ( window.navigator.msPointerEnabled ) {
+            console.log('ractive-events-tap msPointerEnabled');
 			this.node.addEventListener( 'MSPointerUp', handleMouseup, false );
 			document.addEventListener( 'MSPointerMove', handleMousemove, false );
 			document.addEventListener( 'MSPointerCancel', cancel, false );
+			this.node.addEventListener( 'click', handleMouseup, false );
 		} else {
+            console.log('ractive-events-tap pointerless');
 			this.node.addEventListener( 'click', handleMouseup, false );
 			document.addEventListener( 'mousemove', handleMousemove, false );
 		}

--- a/dist/ractive-events-tap.es.js
+++ b/dist/ractive-events-tap.es.js
@@ -30,7 +30,7 @@ TapHandler.prototype = {
 
 		// native buttons, and <input type='button'> elements, should fire a tap event
 		// when the space key is pressed
-		if ( node.tagName === 'BUTTON' || node.type === 'button' ) {
+		if ( node.tagName === 'A' || node.tagName === 'BUTTON' || node.type === 'button' ) {
 			node.addEventListener( 'focus', handleFocus, false );
 		}
 
@@ -94,22 +94,16 @@ TapHandler.prototype = {
 		};
 
 		if ( window.navigator.pointerEnabled ) {
-            console.log('ractive-events-tap pointerEnabled');
 			this.node.addEventListener( 'pointerup', handleMouseup, false );
 			document.addEventListener( 'pointermove', handleMousemove, false );
 			document.addEventListener( 'pointercancel', cancel, false );
-			this.node.addEventListener( 'click', handleMouseup, false );
 		} else if ( window.navigator.msPointerEnabled ) {
-            console.log('ractive-events-tap msPointerEnabled');
 			this.node.addEventListener( 'MSPointerUp', handleMouseup, false );
 			document.addEventListener( 'MSPointerMove', handleMousemove, false );
 			document.addEventListener( 'MSPointerCancel', cancel, false );
-			this.node.addEventListener( 'click', handleMouseup, false );
-		} else {
-            console.log('ractive-events-tap pointerless');
-			this.node.addEventListener( 'click', handleMouseup, false );
-			document.addEventListener( 'mousemove', handleMousemove, false );
 		}
+		this.node.addEventListener( 'click', handleMouseup, false );
+		document.addEventListener( 'mousemove', handleMousemove, false );
 
 		setTimeout( cancel, TIME_THRESHOLD );
 	},
@@ -200,7 +194,7 @@ function handleBlur () {
 }
 
 function handleKeydown ( event ) {
-	if ( event.which === 32 ) { // space key
+	if ( event.which === 32 || event.which === 13 ) { // space key
 		this.__tap_handler__.fire();
 	}
 }

--- a/dist/ractive-events-tap.umd.js
+++ b/dist/ractive-events-tap.umd.js
@@ -107,9 +107,10 @@ TapHandler.prototype = {
 			this.node.addEventListener( 'MSPointerUp', handleMouseup, false );
 			document.addEventListener( 'MSPointerMove', handleMousemove, false );
 			document.addEventListener( 'MSPointerCancel', cancel, false );
+		} else {
+			this.node.addEventListener( 'click', handleMouseup, false );
+			document.addEventListener( 'mousemove', handleMousemove, false );
 		}
-		this.node.addEventListener( 'click', handleMouseup, false );
-		document.addEventListener( 'mousemove', handleMousemove, false );
 
 		setTimeout( cancel, TIME_THRESHOLD );
 	},
@@ -189,18 +190,25 @@ function handleTouchstart ( event ) {
 	this.__tap_handler__.touchdown( event );
 }
 
+function handleFocusClick ( event ) {
+	this.__tap_handler__.fire( event );
+}
+
 function handleFocus () {
 	this.addEventListener( 'keydown', handleKeydown, false );
 	this.addEventListener( 'blur', handleBlur, false );
+	this.addEventListener( 'click', handleFocusClick, false );
 }
 
 function handleBlur () {
 	this.removeEventListener( 'keydown', handleKeydown, false );
 	this.removeEventListener( 'blur', handleBlur, false );
+	this.removeEventListener( 'click', handleFocusClick, false );
 }
 
 function handleKeydown ( event ) {
 	if ( event.which === 32 || event.which === 13 ) { // space key
+		this.removeEventListener( 'click', handleFocusClick, false );
 		this.__tap_handler__.fire();
 	}
 }

--- a/dist/ractive-events-tap.umd.js
+++ b/dist/ractive-events-tap.umd.js
@@ -36,7 +36,7 @@ TapHandler.prototype = {
 
 		// native buttons, and <input type='button'> elements, should fire a tap event
 		// when the space key is pressed
-		if ( node.tagName === 'BUTTON' || node.type === 'button' ) {
+		if ( node.tagName === 'A' || node.tagName === 'BUTTON' || node.type === 'button' ) {
 			node.addEventListener( 'focus', handleFocus, false );
 		}
 
@@ -100,22 +100,16 @@ TapHandler.prototype = {
 		};
 
 		if ( window.navigator.pointerEnabled ) {
-            console.log('ractive-events-tap pointerEnabled');
 			this.node.addEventListener( 'pointerup', handleMouseup, false );
 			document.addEventListener( 'pointermove', handleMousemove, false );
 			document.addEventListener( 'pointercancel', cancel, false );
-			this.node.addEventListener( 'click', handleMouseup, false );
 		} else if ( window.navigator.msPointerEnabled ) {
-            console.log('ractive-events-tap msPointerEnabled');
 			this.node.addEventListener( 'MSPointerUp', handleMouseup, false );
 			document.addEventListener( 'MSPointerMove', handleMousemove, false );
 			document.addEventListener( 'MSPointerCancel', cancel, false );
-			this.node.addEventListener( 'click', handleMouseup, false );
-		} else {
-            console.log('ractive-events-tap pointerless');
-			this.node.addEventListener( 'click', handleMouseup, false );
-			document.addEventListener( 'mousemove', handleMousemove, false );
 		}
+		this.node.addEventListener( 'click', handleMouseup, false );
+		document.addEventListener( 'mousemove', handleMousemove, false );
 
 		setTimeout( cancel, TIME_THRESHOLD );
 	},
@@ -206,7 +200,7 @@ function handleBlur () {
 }
 
 function handleKeydown ( event ) {
-	if ( event.which === 32 ) { // space key
+	if ( event.which === 32 || event.which === 13 ) { // space key
 		this.__tap_handler__.fire();
 	}
 }

--- a/dist/ractive-events-tap.umd.js
+++ b/dist/ractive-events-tap.umd.js
@@ -16,6 +16,7 @@ function TapHandler ( node, callback ) {
 	this.callback = callback;
 
 	this.preventMousedownEvents = false;
+	this.preventClickEvents = false;
 
 	this.bind( node );
 }
@@ -63,6 +64,7 @@ TapHandler.prototype = {
 			return;
 		}
 
+		this.preventClickEvents = true;
 		var x = event.clientX;
 		var y = event.clientY;
 
@@ -112,6 +114,7 @@ TapHandler.prototype = {
 			document.addEventListener( 'mousemove', handleMousemove, false );
 		}
 
+		this.node.removeEventListener( 'click', handleFocusClick, false );
 		setTimeout( cancel, TIME_THRESHOLD );
 	},
 
@@ -191,7 +194,9 @@ function handleTouchstart ( event ) {
 }
 
 function handleFocusClick ( event ) {
-	this.__tap_handler__.fire( event );
+	if (! this.__tap_handler__.preventClickEvents) {
+		this.__tap_handler__.fire( event );
+	}
 }
 
 function handleFocus () {
@@ -204,6 +209,7 @@ function handleBlur () {
 	this.removeEventListener( 'keydown', handleKeydown, false );
 	this.removeEventListener( 'blur', handleBlur, false );
 	this.removeEventListener( 'click', handleFocusClick, false );
+	this.__tap_handler__.preventClickEvents = false;
 }
 
 function handleKeydown ( event ) {

--- a/dist/ractive-events-tap.umd.js
+++ b/dist/ractive-events-tap.umd.js
@@ -2,210 +2,215 @@
 	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
 	(global.Ractive = global.Ractive || {}, global.Ractive.events = global.Ractive.events || {}, global.Ractive.events.tap = factory());
-}(this, function () { 'use strict';
+}(this, (function () { 'use strict';
 
-	var DISTANCE_THRESHOLD = 5; // maximum pixels pointer can move before cancel
-	var TIME_THRESHOLD = 400;   // maximum milliseconds between down and up before cancel
+var DISTANCE_THRESHOLD = 5; // maximum pixels pointer can move before cancel
+var TIME_THRESHOLD = 400;   // maximum milliseconds between down and up before cancel
 
-	function tap ( node, callback ) {
-		return new TapHandler( node, callback );
-	}
+function tap ( node, callback ) {
+	return new TapHandler( node, callback );
+}
 
-	function TapHandler ( node, callback ) {
-		this.node = node;
-		this.callback = callback;
+function TapHandler ( node, callback ) {
+	this.node = node;
+	this.callback = callback;
 
-		this.preventMousedownEvents = false;
+	this.preventMousedownEvents = false;
 
-		this.bind( node );
-	}
+	this.bind( node );
+}
 
-	TapHandler.prototype = {
-		bind: function bind ( node ) {
-			// listen for mouse/pointer events...
-			if (window.navigator.pointerEnabled) {
-				node.addEventListener( 'pointerdown', handleMousedown, false );
-			} else if (window.navigator.msPointerEnabled) {
-				node.addEventListener( 'MSPointerDown', handleMousedown, false );
-			} else {
-				node.addEventListener( 'mousedown', handleMousedown, false );
+TapHandler.prototype = {
+	bind: function bind ( node ) {
+		// listen for mouse/pointer events...
+		if (window.navigator.pointerEnabled) {
+			node.addEventListener( 'pointerdown', handleMousedown, false );
+		} else if (window.navigator.msPointerEnabled) {
+			node.addEventListener( 'MSPointerDown', handleMousedown, false );
+		} else {
+			node.addEventListener( 'mousedown', handleMousedown, false );
 
-				// ...and touch events
-				node.addEventListener( 'touchstart', handleTouchstart, false );
-			}
+			// ...and touch events
+			node.addEventListener( 'touchstart', handleTouchstart, false );
+		}
 
-			// native buttons, and <input type='button'> elements, should fire a tap event
-			// when the space key is pressed
-			if ( node.tagName === 'BUTTON' || node.type === 'button' ) {
-				node.addEventListener( 'focus', handleFocus, false );
-			}
+		// native buttons, and <input type='button'> elements, should fire a tap event
+		// when the space key is pressed
+		if ( node.tagName === 'BUTTON' || node.type === 'button' ) {
+			node.addEventListener( 'focus', handleFocus, false );
+		}
 
-			node.__tap_handler__ = this;
-		},
+		node.__tap_handler__ = this;
+	},
 
-		fire: function fire ( event, x, y ) {
-			this.callback({
-				node: this.node,
-				original: event,
-				x: x,
-				y: y
-			});
-		},
+	fire: function fire ( event, x, y ) {
+		this.callback({
+			node: this.node,
+			original: event,
+			x: x,
+			y: y
+		});
+	},
 
-		mousedown: function mousedown ( event ) {
-			var this$1 = this;
+	mousedown: function mousedown ( event ) {
+		var this$1 = this;
 
-			if ( this.preventMousedownEvents ) {
+		if ( this.preventMousedownEvents ) {
+			return;
+		}
+
+		if ( event.which !== undefined && event.which !== 1 ) {
+			return;
+		}
+
+		var x = event.clientX;
+		var y = event.clientY;
+
+		// This will be null for mouse events.
+		var pointerId = event.pointerId;
+
+		var handleMouseup = function (event) {
+			if ( event.pointerId != pointerId ) {
 				return;
 			}
 
-			if ( event.which !== undefined && event.which !== 1 ) {
+			this$1.fire( event, x, y );
+			cancel();
+		};
+
+		var handleMousemove = function (event) {
+			if ( event.pointerId != pointerId ) {
 				return;
 			}
 
-			var x = event.clientX;
-			var y = event.clientY;
-
-			// This will be null for mouse events.
-			var pointerId = event.pointerId;
-
-			var handleMouseup = function (event) {
-				if ( event.pointerId != pointerId ) {
-					return;
-				}
-
-				this$1.fire( event, x, y );
+			if ( ( Math.abs( event.clientX - x ) >= DISTANCE_THRESHOLD ) || ( Math.abs( event.clientY - y ) >= DISTANCE_THRESHOLD ) ) {
 				cancel();
-			};
+			}
+		};
 
-			var handleMousemove = function (event) {
-				if ( event.pointerId != pointerId ) {
-					return;
-				}
+		var cancel = function () {
+			this$1.node.removeEventListener( 'MSPointerUp', handleMouseup, false );
+			document.removeEventListener( 'MSPointerMove', handleMousemove, false );
+			document.removeEventListener( 'MSPointerCancel', cancel, false );
+			this$1.node.removeEventListener( 'pointerup', handleMouseup, false );
+			document.removeEventListener( 'pointermove', handleMousemove, false );
+			document.removeEventListener( 'pointercancel', cancel, false );
+			this$1.node.removeEventListener( 'click', handleMouseup, false );
+			document.removeEventListener( 'mousemove', handleMousemove, false );
+		};
 
-				if ( ( Math.abs( event.clientX - x ) >= DISTANCE_THRESHOLD ) || ( Math.abs( event.clientY - y ) >= DISTANCE_THRESHOLD ) ) {
-					cancel();
-				}
-			};
+		if ( window.navigator.pointerEnabled ) {
+            console.log('ractive-events-tap pointerEnabled');
+			this.node.addEventListener( 'pointerup', handleMouseup, false );
+			document.addEventListener( 'pointermove', handleMousemove, false );
+			document.addEventListener( 'pointercancel', cancel, false );
+			this.node.addEventListener( 'click', handleMouseup, false );
+		} else if ( window.navigator.msPointerEnabled ) {
+            console.log('ractive-events-tap msPointerEnabled');
+			this.node.addEventListener( 'MSPointerUp', handleMouseup, false );
+			document.addEventListener( 'MSPointerMove', handleMousemove, false );
+			document.addEventListener( 'MSPointerCancel', cancel, false );
+			this.node.addEventListener( 'click', handleMouseup, false );
+		} else {
+            console.log('ractive-events-tap pointerless');
+			this.node.addEventListener( 'click', handleMouseup, false );
+			document.addEventListener( 'mousemove', handleMousemove, false );
+		}
 
-			var cancel = function () {
-				this$1.node.removeEventListener( 'MSPointerUp', handleMouseup, false );
-				document.removeEventListener( 'MSPointerMove', handleMousemove, false );
-				document.removeEventListener( 'MSPointerCancel', cancel, false );
-				this$1.node.removeEventListener( 'pointerup', handleMouseup, false );
-				document.removeEventListener( 'pointermove', handleMousemove, false );
-				document.removeEventListener( 'pointercancel', cancel, false );
-				this$1.node.removeEventListener( 'click', handleMouseup, false );
-				document.removeEventListener( 'mousemove', handleMousemove, false );
-			};
+		setTimeout( cancel, TIME_THRESHOLD );
+	},
 
-			if ( window.navigator.pointerEnabled ) {
-				this.node.addEventListener( 'pointerup', handleMouseup, false );
-				document.addEventListener( 'pointermove', handleMousemove, false );
-				document.addEventListener( 'pointercancel', cancel, false );
-			} else if ( window.navigator.msPointerEnabled ) {
-				this.node.addEventListener( 'MSPointerUp', handleMouseup, false );
-				document.addEventListener( 'MSPointerMove', handleMousemove, false );
-				document.addEventListener( 'MSPointerCancel', cancel, false );
-			} else {
-				this.node.addEventListener( 'click', handleMouseup, false );
-				document.addEventListener( 'mousemove', handleMousemove, false );
+	touchdown: function touchdown ( event ) {
+		var this$1 = this;
+
+		var touch = event.touches[0];
+
+		var x = touch.clientX;
+		var y = touch.clientY;
+
+		var finger = touch.identifier;
+
+		var handleTouchup = function (event) {
+			var touch = event.changedTouches[0];
+
+			if ( touch.identifier !== finger ) {
+				cancel();
+				return;
 			}
 
-			setTimeout( cancel, TIME_THRESHOLD );
-		},
+			event.preventDefault(); // prevent compatibility mouse event
 
-		touchdown: function touchdown ( event ) {
-			var this$1 = this;
+			// for the benefit of mobile Firefox and old Android browsers, we need this absurd hack.
+			this$1.preventMousedownEvents = true;
+			clearTimeout( this$1.preventMousedownTimeout );
+
+			this$1.preventMousedownTimeout = setTimeout( function () {
+				this$1.preventMousedownEvents = false;
+			}, 400 );
+
+			this$1.fire( event, x, y );
+			cancel();
+		};
+
+		var handleTouchmove = function (event) {
+			if ( event.touches.length !== 1 || event.touches[0].identifier !== finger ) {
+				cancel();
+			}
 
 			var touch = event.touches[0];
-
-			var x = touch.clientX;
-			var y = touch.clientY;
-
-			var finger = touch.identifier;
-
-			var handleTouchup = function (event) {
-				var touch = event.changedTouches[0];
-
-				if ( touch.identifier !== finger ) {
-					cancel();
-					return;
-				}
-
-				event.preventDefault(); // prevent compatibility mouse event
-
-				// for the benefit of mobile Firefox and old Android browsers, we need this absurd hack.
-				this$1.preventMousedownEvents = true;
-				clearTimeout( this$1.preventMousedownTimeout );
-
-				this$1.preventMousedownTimeout = setTimeout( function () {
-					this$1.preventMousedownEvents = false;
-				}, 400 );
-
-				this$1.fire( event, x, y );
+			if ( ( Math.abs( touch.clientX - x ) >= DISTANCE_THRESHOLD ) || ( Math.abs( touch.clientY - y ) >= DISTANCE_THRESHOLD ) ) {
 				cancel();
-			};
+			}
+		};
 
-			var handleTouchmove = function (event) {
-				if ( event.touches.length !== 1 || event.touches[0].identifier !== finger ) {
-					cancel();
-				}
+		var cancel = function () {
+			this$1.node.removeEventListener( 'touchend', handleTouchup, false );
+			window.removeEventListener( 'touchmove', handleTouchmove, false );
+			window.removeEventListener( 'touchcancel', cancel, false );
+		};
 
-				var touch = event.touches[0];
-				if ( ( Math.abs( touch.clientX - x ) >= DISTANCE_THRESHOLD ) || ( Math.abs( touch.clientY - y ) >= DISTANCE_THRESHOLD ) ) {
-					cancel();
-				}
-			};
+		this.node.addEventListener( 'touchend', handleTouchup, false );
+		window.addEventListener( 'touchmove', handleTouchmove, false );
+		window.addEventListener( 'touchcancel', cancel, false );
 
-			var cancel = function () {
-				this$1.node.removeEventListener( 'touchend', handleTouchup, false );
-				window.removeEventListener( 'touchmove', handleTouchmove, false );
-				window.removeEventListener( 'touchcancel', cancel, false );
-			};
+		setTimeout( cancel, TIME_THRESHOLD );
+	},
 
-			this.node.addEventListener( 'touchend', handleTouchup, false );
-			window.addEventListener( 'touchmove', handleTouchmove, false );
-			window.addEventListener( 'touchcancel', cancel, false );
+	teardown: function teardown () {
+		var node = this.node;
 
-			setTimeout( cancel, TIME_THRESHOLD );
-		},
-
-		teardown: function teardown () {
-			var node = this.node;
-
-			node.removeEventListener( 'pointerdown',   handleMousedown, false );
-			node.removeEventListener( 'MSPointerDown', handleMousedown, false );
-			node.removeEventListener( 'mousedown',     handleMousedown, false );
-			node.removeEventListener( 'touchstart',    handleTouchstart, false );
-			node.removeEventListener( 'focus',         handleFocus, false );
-		}
-	};
-
-	function handleMousedown ( event ) {
-		this.__tap_handler__.mousedown( event );
+		node.removeEventListener( 'pointerdown',   handleMousedown, false );
+		node.removeEventListener( 'MSPointerDown', handleMousedown, false );
+		node.removeEventListener( 'mousedown',     handleMousedown, false );
+		node.removeEventListener( 'touchstart',    handleTouchstart, false );
+		node.removeEventListener( 'focus',         handleFocus, false );
 	}
+};
 
-	function handleTouchstart ( event ) {
-		this.__tap_handler__.touchdown( event );
+function handleMousedown ( event ) {
+	this.__tap_handler__.mousedown( event );
+}
+
+function handleTouchstart ( event ) {
+	this.__tap_handler__.touchdown( event );
+}
+
+function handleFocus () {
+	this.addEventListener( 'keydown', handleKeydown, false );
+	this.addEventListener( 'blur', handleBlur, false );
+}
+
+function handleBlur () {
+	this.removeEventListener( 'keydown', handleKeydown, false );
+	this.removeEventListener( 'blur', handleBlur, false );
+}
+
+function handleKeydown ( event ) {
+	if ( event.which === 32 ) { // space key
+		this.__tap_handler__.fire();
 	}
+}
 
-	function handleFocus () {
-		this.addEventListener( 'keydown', handleKeydown, false );
-		this.addEventListener( 'blur', handleBlur, false );
-	}
+return tap;
 
-	function handleBlur () {
-		this.removeEventListener( 'keydown', handleKeydown, false );
-		this.removeEventListener( 'blur', handleBlur, false );
-	}
-
-	function handleKeydown ( event ) {
-		if ( event.which === 32 ) { // space key
-			this.__tap_handler__.fire();
-		}
-	}
-
-	return tap;
-
-}));
+})));

--- a/src/ractive-events-tap.js
+++ b/src/ractive-events-tap.js
@@ -92,16 +92,19 @@ TapHandler.prototype = {
 		};
 
 		if ( window.navigator.pointerEnabled ) {
+            console.log('ractive-events-tap pointerEnabled');
 			this.node.addEventListener( 'pointerup', handleMouseup, false );
 			document.addEventListener( 'pointermove', handleMousemove, false );
 			document.addEventListener( 'pointercancel', cancel, false );
 			this.node.addEventListener( 'click', handleMouseup, false );
 		} else if ( window.navigator.msPointerEnabled ) {
+            console.log('ractive-events-tap msPointerEnabled');
 			this.node.addEventListener( 'MSPointerUp', handleMouseup, false );
 			document.addEventListener( 'MSPointerMove', handleMousemove, false );
 			document.addEventListener( 'MSPointerCancel', cancel, false );
 			this.node.addEventListener( 'click', handleMouseup, false );
 		} else {
+            console.log('ractive-events-tap pointerless');
 			this.node.addEventListener( 'click', handleMouseup, false );
 			document.addEventListener( 'mousemove', handleMousemove, false );
 		}

--- a/src/ractive-events-tap.js
+++ b/src/ractive-events-tap.js
@@ -96,18 +96,15 @@ TapHandler.prototype = {
 			this.node.addEventListener( 'pointerup', handleMouseup, false );
 			document.addEventListener( 'pointermove', handleMousemove, false );
 			document.addEventListener( 'pointercancel', cancel, false );
-			this.node.addEventListener( 'click', handleMouseup, false );
 		} else if ( window.navigator.msPointerEnabled ) {
             console.log('ractive-events-tap msPointerEnabled');
 			this.node.addEventListener( 'MSPointerUp', handleMouseup, false );
 			document.addEventListener( 'MSPointerMove', handleMousemove, false );
 			document.addEventListener( 'MSPointerCancel', cancel, false );
-			this.node.addEventListener( 'click', handleMouseup, false );
-		} else {
-            console.log('ractive-events-tap pointerless');
-			this.node.addEventListener( 'click', handleMouseup, false );
-			document.addEventListener( 'mousemove', handleMousemove, false );
 		}
+        console.log('ractive-events-tap pointerless');
+		this.node.addEventListener( 'click', handleMouseup, false );
+		document.addEventListener( 'mousemove', handleMousemove, false );
 
 		setTimeout( cancel, TIME_THRESHOLD );
 	},
@@ -196,7 +193,7 @@ function handleBlur () {
 }
 
 function handleKeydown ( event ) {
-	if ( event.which === 32 ) { // space key
+	if ( event.which === 32 || event.which === 13 ) { // space key
 		this.__tap_handler__.fire();
 	}
 }

--- a/src/ractive-events-tap.js
+++ b/src/ractive-events-tap.js
@@ -10,6 +10,7 @@ function TapHandler ( node, callback ) {
 	this.callback = callback;
 
 	this.preventMousedownEvents = false;
+	this.preventClickEvents = false;
 
 	this.bind( node );
 }
@@ -55,6 +56,7 @@ TapHandler.prototype = {
 			return;
 		}
 
+		this.preventClickEvents = true;
 		const x = event.clientX;
 		const y = event.clientY;
 
@@ -104,6 +106,7 @@ TapHandler.prototype = {
 			document.addEventListener( 'mousemove', handleMousemove, false );
 		}
 
+		this.node.removeEventListener( 'click', handleFocusClick, false );
 		setTimeout( cancel, TIME_THRESHOLD );
 	},
 
@@ -181,7 +184,9 @@ function handleTouchstart ( event ) {
 }
 
 function handleFocusClick ( event ) {
-	this.__tap_handler__.fire( event );
+	if (! this.__tap_handler__.preventClickEvents) {
+		this.__tap_handler__.fire( event );
+	}
 }
 
 function handleFocus () {
@@ -194,6 +199,7 @@ function handleBlur () {
 	this.removeEventListener( 'keydown', handleKeydown, false );
 	this.removeEventListener( 'blur', handleBlur, false );
 	this.removeEventListener( 'click', handleFocusClick, false );
+	this.__tap_handler__.preventClickEvents = false;
 }
 
 function handleKeydown ( event ) {

--- a/src/ractive-events-tap.js
+++ b/src/ractive-events-tap.js
@@ -99,9 +99,10 @@ TapHandler.prototype = {
 			this.node.addEventListener( 'MSPointerUp', handleMouseup, false );
 			document.addEventListener( 'MSPointerMove', handleMousemove, false );
 			document.addEventListener( 'MSPointerCancel', cancel, false );
+		} else {
+			this.node.addEventListener( 'click', handleMouseup, false );
+			document.addEventListener( 'mousemove', handleMousemove, false );
 		}
-		this.node.addEventListener( 'click', handleMouseup, false );
-		document.addEventListener( 'mousemove', handleMousemove, false );
 
 		setTimeout( cancel, TIME_THRESHOLD );
 	},

--- a/src/ractive-events-tap.js
+++ b/src/ractive-events-tap.js
@@ -95,10 +95,12 @@ TapHandler.prototype = {
 			this.node.addEventListener( 'pointerup', handleMouseup, false );
 			document.addEventListener( 'pointermove', handleMousemove, false );
 			document.addEventListener( 'pointercancel', cancel, false );
+			this.node.addEventListener( 'click', handleMouseup, false );
 		} else if ( window.navigator.msPointerEnabled ) {
 			this.node.addEventListener( 'MSPointerUp', handleMouseup, false );
 			document.addEventListener( 'MSPointerMove', handleMousemove, false );
 			document.addEventListener( 'MSPointerCancel', cancel, false );
+			this.node.addEventListener( 'click', handleMouseup, false );
 		} else {
 			this.node.addEventListener( 'click', handleMouseup, false );
 			document.addEventListener( 'mousemove', handleMousemove, false );

--- a/src/ractive-events-tap.js
+++ b/src/ractive-events-tap.js
@@ -180,18 +180,25 @@ function handleTouchstart ( event ) {
 	this.__tap_handler__.touchdown( event );
 }
 
+function handleFocusClick ( event ) {
+	this.__tap_handler__.fire( event );
+}
+
 function handleFocus () {
 	this.addEventListener( 'keydown', handleKeydown, false );
 	this.addEventListener( 'blur', handleBlur, false );
+	this.addEventListener( 'click', handleFocusClick, false );
 }
 
 function handleBlur () {
 	this.removeEventListener( 'keydown', handleKeydown, false );
 	this.removeEventListener( 'blur', handleBlur, false );
+	this.removeEventListener( 'click', handleFocusClick, false );
 }
 
 function handleKeydown ( event ) {
 	if ( event.which === 32 || event.which === 13 ) { // space key
+		this.removeEventListener( 'click', handleFocusClick, false );
 		this.__tap_handler__.fire();
 	}
 }

--- a/src/ractive-events-tap.js
+++ b/src/ractive-events-tap.js
@@ -30,7 +30,7 @@ TapHandler.prototype = {
 
 		// native buttons, and <input type='button'> elements, should fire a tap event
 		// when the space key is pressed
-		if ( node.tagName === 'BUTTON' || node.type === 'button' ) {
+		if ( node.tagName === 'A' || node.tagName === 'BUTTON' || node.type === 'button' ) {
 			node.addEventListener( 'focus', handleFocus, false );
 		}
 
@@ -92,17 +92,14 @@ TapHandler.prototype = {
 		};
 
 		if ( window.navigator.pointerEnabled ) {
-            console.log('ractive-events-tap pointerEnabled');
 			this.node.addEventListener( 'pointerup', handleMouseup, false );
 			document.addEventListener( 'pointermove', handleMousemove, false );
 			document.addEventListener( 'pointercancel', cancel, false );
 		} else if ( window.navigator.msPointerEnabled ) {
-            console.log('ractive-events-tap msPointerEnabled');
 			this.node.addEventListener( 'MSPointerUp', handleMouseup, false );
 			document.addEventListener( 'MSPointerMove', handleMousemove, false );
 			document.addEventListener( 'MSPointerCancel', cancel, false );
 		}
-        console.log('ractive-events-tap pointerless');
 		this.node.addEventListener( 'click', handleMouseup, false );
 		document.addEventListener( 'mousemove', handleMousemove, false );
 


### PR DESCRIPTION
This change is to allow ractive-events-tap to work with the screen reader/accessibility tool JAWS when using IE.
It also expands the listening of keyboard events to enter presses also when on anchor tags.
The problem is caused because JAWS swallows all keyboard events and emits only a click event (it doesn't emit the mouse down/mouse up events).